### PR TITLE
Improve Renko initialization and callback handling

### DIFF
--- a/src/ProfitDLLClient/RenkoTradeMonitor.cs
+++ b/src/ProfitDLLClient/RenkoTradeMonitor.cs
@@ -47,7 +47,8 @@ namespace Edison.Trading.ProfitDLLClient
         public void Stop()
         {
             ProfitDLL.UnsubscribeTicker(_symbol, _exchange);
-            // Não há método para remover callback, mas pode-se sobrescrever se necessário
+            ProfitDLL.SetTradeCallbackV2(null);
+            _renkoGenerator.OnCloseBrick -= HandleNewBrick;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- allow renko trade monitor to unregister callbacks to avoid GC issues
- expose `TryLoadLastBrickFromDisk` and `InitializeFromLastBrick` on the Renko generator
- query last closing price when starting the renko monitor and ask user for brick direction

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d74a1d7a0832a97cfb14b4f526227