### PR TITLE
Fix unsubscribe messages

### DIFF
--- a/src/ProfitDLLClient/DLLConnector.cs
+++ b/src/ProfitDLLClient/DLLConnector.cs
@@ -186,11 +186,11 @@ public partial class DLLConnector
         var retVal = UnsubscribeTicker(split[0], split[1]);
         if (retVal == NL_OK)
         {
-            WriteSync("Subscribe com sucesso");
+            WriteSync("Unsubscribe com sucesso");
         }
         else
         {
-            WriteSync($"Erro no subscribe: {retVal}");
+            WriteSync($"Erro no unsubscribe: {retVal}");
         }
     }
 


### PR DESCRIPTION
## Summary
- update `UnsubscribeAsset` messages

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d4ac82ad0832abe2356cf71423f4e