### PR TITLE
Fix Portuguese prompt typos

### DIFF
--- a/docs/Program.cs
+++ b/docs/Program.cs
@@ -823,7 +823,7 @@ public partial class DLLConnector
 
         do
         {
-            Console.Write("Código do conta (ex 1171:12345:1): ");
+            Console.Write("Código da conta (ex 1171:12345:1): ");
             input = Console.ReadLine();
         } while (!Regex.IsMatch(input, @"\d+:\d+(:\d+)?"));
 
@@ -885,7 +885,7 @@ public partial class DLLConnector
 
         do
         {
-            Console.Write("Código do conta (ex 1171:12345:1): ");
+            Console.Write("Código da conta (ex 1171:12345:1): ");
             input = Console.ReadLine();
         } while (!Regex.IsMatch(input, @"\d+:\d+(:\d+)?"));
 

--- a/src/ProfitDLLClient/DLLConnector.cs
+++ b/src/ProfitDLLClient/DLLConnector.cs
@@ -58,7 +58,7 @@ public partial class DLLConnector
         string? input;
         do
         {
-            Console.Write("Código do conta (ex 1171:12345:1): ");
+            Console.Write("Código da conta (ex 1171:12345:1): ");
             input = Console.ReadLine();
         } while (string.IsNullOrWhiteSpace(input) || !Regex.IsMatch(input, @"\d+:\d+(:\d+)?"));
 
@@ -290,7 +290,7 @@ public partial class DLLConnector
 
         do
         {
-            Console.Write("Código do conta (ex 1171:12345:1): ");
+            Console.Write("Código da conta (ex 1171:12345:1): ");
             input = Console.ReadLine();
         } while (string.IsNullOrWhiteSpace(input) || !Regex.IsMatch(input, @"\d+:\d+(:\d+)?"));
 


### PR DESCRIPTION
## Summary
- correct Portuguese prompt in DLLConnector
- update docs to match corrected text

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d4aba4780832a8066c4721a34fd28