### PR TITLE
Add .NET build instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# Meu Projeto
+# Trading Bot
+
+This repository contains the source code for a trading bot and its supporting libraries.
+
+## Prerequisites
+
+- .NET SDK **8.0.411** (see `global.json`)
+
+## Restoring dependencies
+
+Run the following command from the repository root to download all NuGet packages:
+
+```bash
+dotnet restore
+```
+
+## Building the solution
+
+Compile all projects in the solution using:
+
+```bash
+dotnet build
+```
+
+## Running tests
+
+Execute the unit tests with:
+
+```bash
+dotnet test
+```


### PR DESCRIPTION
## Summary
- document requirements for .NET SDK 8.0.411
- provide commands to restore packages, build the solution and run tests

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d875877e8832a88996d1bcc8a3045