### PR TITLE
Fix callback references

### DIFF
--- a/src/ProfitDLLClient/DLLConnector.cs
+++ b/src/ProfitDLLClient/DLLConnector.cs
@@ -353,14 +353,6 @@ public partial class DLLConnector
     {
         int retVal;
         bool bRoteamento = true;
-        static void EmptyHistoryCallback(TAssetID AssetID, int nCorretora, int nQtd, int nTradedQtd, int nLeavesQtd, int Side, double sPrice, double sStopPrice, double sAvgPrice, long nProfitID,
-            string TipoOrdem, string Conta, string Titular, string ClOrdID, string Status, string Date) { }
-        static void EmptyOrderChangeCallback(TAssetID assetId, int nCorretora, int nQtd, int nTradedQtd, int nLeavesQtd, int Side, double sPrice, double sStopPrice, double sAvgPrice, long nProfitID,
-            string TipoOrdem, string Conta, string Titular, string ClOrdID, string Status, string Date, string TextMessage) { }
-        static void EmptyTradeCallback(TAssetID assetId, string date, uint tradeNumber, double price, double vol, int qtd, int buyAgent, int sellAgent, int tradeType, int bIsEdit) { }
-        static void EmptyOfferBookCallback(TAssetID assetId, int nAction, int nPosition, int Side, int nQtd, int nAgent, long nOfferID, double sPrice, int bHasPrice, int bHasQtd, int bHasDate, int bHasOfferID, int bHasAgent, string date, IntPtr pArraySell, IntPtr pArrayBuy) { }
-        static void EmptyHistoryTradeCallback(TAssetID assetId, string date, uint tradeNumber, double price, double vol, int qtd, int buyAgent, int sellAgent, int tradeType) { }
-        static void EmptyProgressCallback(TAssetID assetId, int nProgress) { }
         if (bRoteamento)
         {
             retVal = ProfitDLL.DLLInitializeLogin(
@@ -475,6 +467,14 @@ public partial class DLLConnector
         public static void OrderHistoryCallback(TConnectorAccountIdentifier accountId) { }
         public static void TradeCallback(TConnectorAssetIdentifier a_Asset, nint a_pTrade, [MarshalAs(UnmanagedType.U4)] TConnectorTradeCallbackFlags a_nFlags) { }
         public static void HistoryTradeCallback(TConnectorAssetIdentifier a_Asset, nint a_pTrade, [MarshalAs(UnmanagedType.U4)] TConnectorTradeCallbackFlags a_nFlags) { }
+        public static void EmptyHistoryCallback(TAssetID AssetID, int nCorretora, int nQtd, int nTradedQtd, int nLeavesQtd, int Side, double sPrice, double sStopPrice, double sAvgPrice, long nProfitID,
+            string TipoOrdem, string Conta, string Titular, string ClOrdID, string Status, string Date) { }
+        public static void EmptyOrderChangeCallback(TAssetID assetId, int nCorretora, int nQtd, int nTradedQtd, int nLeavesQtd, int Side, double sPrice, double sStopPrice, double sAvgPrice, long nProfitID,
+            string TipoOrdem, string Conta, string Titular, string ClOrdID, string Status, string Date, string TextMessage) { }
+        public static void EmptyTradeCallback(TAssetID assetId, string date, uint tradeNumber, double price, double vol, int qtd, int buyAgent, int sellAgent, int tradeType, int bIsEdit) { }
+        public static void EmptyOfferBookCallback(TAssetID assetId, int nAction, int nPosition, int Side, int nQtd, int nAgent, long nOfferID, double sPrice, int bHasPrice, int bHasQtd, int bHasDate, int bHasOfferID, int bHasAgent, string date, IntPtr pArraySell, IntPtr pArrayBuy) { }
+        public static void EmptyHistoryTradeCallback(TAssetID assetId, string date, uint tradeNumber, double price, double vol, int qtd, int buyAgent, int sellAgent, int tradeType) { }
+        public static void EmptyProgressCallback(TAssetID assetId, int nProgress) { }
 
         #region obj garbage KeepAlive
         public static TAssetListCallback _assetListCallback = new TAssetListCallback(AssetListCallback);


### PR DESCRIPTION
## Summary
- remove unused local callback functions
- add public static callback stubs so delegate assignments compile

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d8e4f4cbc832ab9c63f044c31c419