### PR TITLE
Fix duplicate TargetFramework attribute build error

### DIFF
--- a/Edison.Trading.csproj
+++ b/Edison.Trading.csproj
@@ -15,6 +15,8 @@
     <Compile Remove="src\Core\**\*.cs" />
     <Compile Remove="tests\**\*.cs" />
     <Compile Remove="docs\**\*.cs" />
+    <!-- Exclude generated files from nested project obj folders -->
+    <Compile Remove="**\obj\**\*.cs" />
     <ProjectReference Include="src\Core\Edison.Trading.Core.csproj" />
     <None Include="ProfitDLL.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
## Summary
- exclude generated `obj` files from main project compilation

## Testing
- `dotnet restore`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_686d9b8abdf0832a81cf18f37f01d718