### PR TITLE
Fix null dereference warning

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -122,7 +122,7 @@ namespace Edison.Trading.Program
 
                     double lastClose;
                     RenkoDirection direction;
-                    if (renkoGen.TryLoadLastBrickFromDisk(out var lastBrick))
+                    if (renkoGen.TryLoadLastBrickFromDisk(out var lastBrick) && lastBrick is not null)
                     {
                         lastClose = lastBrick.Close;
                         direction = lastBrick.Direction;


### PR DESCRIPTION
## Summary
- ensure `lastBrick` is not null before using it

## Testing
- `dotnet build`
- `dotnet test --no-build --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_686d9c0b3bd8832abbf0b3de0072f728