### PR TITLE
Fix nullability warning in renko generator

### DIFF
--- a/src/Core/NelogicaRenkoGenerator.cs
+++ b/src/Core/NelogicaRenkoGenerator.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Google.Protobuf;
+using System.Diagnostics.CodeAnalysis;
 
 
 namespace Edison.Trading.Core
@@ -109,7 +110,7 @@ public class NelogicaRenkoGenerator
         _saveIntervalSeconds = saveIntervalSeconds;
     }
 
-    public bool TryLoadLastBrickFromDisk(out RenkoBrick? lastBrick)
+    public bool TryLoadLastBrickFromDisk([NotNullWhen(true)] out RenkoBrick? lastBrick)
     {
         lastBrick = null;
         if (!File.Exists(_saveFilePath))


### PR DESCRIPTION
## Summary
- ensure `TryLoadLastBrickFromDisk` reports non-null output when successful

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d9c0b3bd8832abbf0b3de0072f728