### PR TITLE
Ensure UTC conversion in SystemTime parsing

### DIFF
--- a/src/Core/ProfitDataTypes.cs
+++ b/src/Core/ProfitDataTypes.cs
@@ -439,7 +439,15 @@ public struct SystemTime
 
     public static DateTime ToDateTime(SystemTime date)
     {
-        return new DateTime(date.Year, date.Month, date.Day, date.Hour, date.Minute, date.Second, date.Milliseconds);
+        return new DateTime(
+            date.Year,
+            date.Month,
+            date.Day,
+            date.Hour,
+            date.Minute,
+            date.Second,
+            date.Milliseconds,
+            DateTimeKind.Utc);
     }
 
     public override string ToString() => ToDateTime(this).ToString();


### PR DESCRIPTION
## Summary
- always convert `SystemTime` to `DateTime` with `DateTimeKind.Utc`

## Testing
- `dotnet test Edison.Trading.sln`

------
https://chatgpt.com/codex/tasks/task_e_686dde822830832a971f6a6793c471a2