### PR TITLE
Fix incorrect using statement in IsotonicCalibrator

### DIFF
--- a/src/Core/IsotonicCalibrator.cs
+++ b/src/Core/IsotonicCalibrator.cs
@@ -67,7 +67,7 @@ namespace Edison.Trading.Core
                     inputTensor[i, j] = featureMatrix[i][j];
             }
 
-            using var inputs = new List<NamedOnnxValue> { NamedOnnxValue.CreateFromTensor(inputName, inputTensor) };
+            var inputs = new List<NamedOnnxValue> { NamedOnnxValue.CreateFromTensor(inputName, inputTensor) };
             using var results = _session.Run(inputs);
             var rawScores = results.First().AsEnumerable<float>().ToArray();
 
@@ -88,7 +88,7 @@ namespace Edison.Trading.Core
                 throw new ArgumentException("Número de features incorreto.");
 
             var inputTensor = new DenseTensor<float>(features, new[] { 1, features.Length });
-            using var inputs = new List<NamedOnnxValue> { NamedOnnxValue.CreateFromTensor(inputName, inputTensor) };
+            var inputs = new List<NamedOnnxValue> { NamedOnnxValue.CreateFromTensor(inputName, inputTensor) };
             using var results = _session.Run(inputs);
             return results.First().AsEnumerable<float>().First();
         }


### PR DESCRIPTION
## Summary
- update `IsotonicCalibrator` to remove `using` on `List<NamedOnnxValue>`
- this prevents build errors about `List<NamedOnnxValue>` not being `IDisposable`

## Testing
- `dotnet build`
- `dotnet test` *(fails: Load model ... File doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_686e2afbf4ec832aadf9afa569bb7527