### PR TITLE
Fix synchronous renko event handling

### DIFF
--- a/src/Core/NelogicaRenkoGenerator.cs
+++ b/src/Core/NelogicaRenkoGenerator.cs
@@ -417,9 +417,9 @@ public class NelogicaRenkoGenerator
                 _renkoBuffer.TryDequeue(out _);
         }
 
-        // Save and calculate features concurrently
-        _ = Task.Run(() => AppendBrickToFile(newBrick));
-        _ = Task.Run(() => OnCloseBrick?.Invoke(newBrick));
+        // Persist brick and notify synchronously
+        AppendBrickToFile(newBrick);
+        OnCloseBrick?.Invoke(newBrick);
     }
 
     private void AddBricksSeries(double openPrice, double totalMovement, SystemTime timestamp)


### PR DESCRIPTION
## Summary
- invoke `OnCloseBrick` directly instead of scheduling on `Task.Run`

## Testing
- `dotnet test tests/Edison.Trading.Tests.csproj -v normal`

------
https://chatgpt.com/codex/tasks/task_e_686f62a249fc832a875513188a7c4cd0