### PR TITLE
Fix stop method nullable delegate call

### DIFF
--- a/src/ProfitDLLClient/RenkoTradeMonitor.cs
+++ b/src/ProfitDLLClient/RenkoTradeMonitor.cs
@@ -53,7 +53,8 @@ namespace Edison.Trading.ProfitDLLClient
         public void Stop()
         {
             ProfitDLL.UnsubscribeTicker(_symbol, _exchange);
-            ProfitDLL.SetTradeCallbackV2(null);
+            // P/Invoke permite null, mas a assinatura não é anulável
+            ProfitDLL.SetTradeCallbackV2(null!);
             _renkoGenerator.OnCloseBrick -= _brickBuffer.AddBrick;
             _renkoGenerator.OnCloseBrick -= HandleNewBrick;
         }


### PR DESCRIPTION
## Summary
- allow null pointer when removing the trade callback in `RenkoTradeMonitor`

## Testing
- `dotnet build`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_686f6a443168832a8f072eefcf023c3a