### PR TITLE
Fix account ID marshaling

### DIFF
--- a/docs/ProfitDataTypes.cs
+++ b/docs/ProfitDataTypes.cs
@@ -135,10 +135,10 @@ public struct TConnectorAccountIdentifierOut
 {
     public byte Version;
     public int BrokerID;
-    [MarshalAs(UnmanagedType.ByValArray, SizeConst = 100)]
+    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 100)]
     public string AccountID;
     public int AccountIDLength;
-    [MarshalAs(UnmanagedType.ByValArray, SizeConst = 100)]
+    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 100)]
     public string SubAccountID;
     public int SubAccountIDLength;
     public long Reserved;

--- a/src/Core/ProfitDataTypes.cs
+++ b/src/Core/ProfitDataTypes.cs
@@ -190,10 +190,10 @@ public struct TConnectorAccountIdentifierOut
 {
     public byte Version;
     public int BrokerID;
-    [MarshalAs(UnmanagedType.ByValArray, SizeConst = 100)]
+    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 100)]
     public string AccountID;
     public int AccountIDLength;
-    [MarshalAs(UnmanagedType.ByValArray, SizeConst = 100)]
+    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 100)]
     public string SubAccountID;
     public int SubAccountIDLength;
     public long Reserved;


### PR DESCRIPTION
## Summary
- use `ByValTStr` for string fields inside `TConnectorAccountIdentifierOut`
- update docs to match the struct definition

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686faf111f7c832a9c63e0ac1bbba4ac