### PR TITLE
Handle SetActiveAccount not present

### DIFF
--- a/src/Core/ProfitFunctions.cs
+++ b/src/Core/ProfitFunctions.cs
@@ -294,6 +294,21 @@ public class ProfitDLL
     [DllImport(dll_path, CallingConvention = CallingConvention.StdCall)]
     public static extern int SetActiveAccount([MarshalAs(UnmanagedType.LPWStr)] string accountId);
 
+    /// <summary>
+    /// Tenta definir a conta ativa na DLL. Caso a função não exista, retorna false.
+    /// </summary>
+    public static bool TrySetActiveAccount(string accountId)
+    {
+        try
+        {
+            return SetActiveAccount(accountId) == 0;
+        }
+        catch (EntryPointNotFoundException)
+        {
+            return false;
+        }
+    }
+
     public static string[] ListAccounts()
     {
         int count = GetAccountCount();

--- a/src/ProfitDLLClient/RenkoTradeMonitor.cs
+++ b/src/ProfitDLLClient/RenkoTradeMonitor.cs
@@ -160,7 +160,10 @@ namespace Edison.Trading.ProfitDLLClient
                 return;
             }
 
-            ProfitDLL.SetActiveAccount(chosen);
+            if (!ProfitDLL.TrySetActiveAccount(chosen))
+            {
+                Console.WriteLine("⚠️ Função SetActiveAccount não disponível. Conta selecionada apenas localmente.");
+            }
             _selectedAccount = chosen;
             Console.WriteLine($"Conta ativa: {chosen}");
         }


### PR DESCRIPTION
## Summary
- add TrySetActiveAccount to handle EntryPointNotFoundException
- warn user when SetActiveAccount is unavailable

## Testing
- `dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686fb4799b68832a9c963521311d403f