### PR TITLE
Add history fetch customization and fix brick persistence

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -150,6 +150,15 @@ namespace Edison.Trading.Program
                     renkoGen.InitializeFromLastBrick(lastClose, direction);
                     monitor = new RenkoTradeMonitor(parts[0], parts[1], 15, 5.0, renkoGen);
                     monitor.SelectAccount();
+
+                    ProfitDLLClient.DLLConnector.WriteSync("Data/hora início do histórico (dd/MM/yyyy HH:mm:ss.fff ou enter p/ ignorar): ");
+                    string? startInput = Console.ReadLine();
+                    if (!string.IsNullOrWhiteSpace(startInput) &&
+                        DateTime.TryParseExact(startInput, "dd/MM/yyyy HH:mm:ss.fff", CultureInfo.InvariantCulture, DateTimeStyles.None, out var startDate))
+                    {
+                        monitor.RequestHistory(startDate, DateTime.Now);
+                    }
+
                     monitor.Start();
                     ProfitDLLClient.DLLConnector.WriteSync("🔄 Monitor Renko iniciado. Use 'stop renko' para parar.");
                     break;

--- a/src/Core/RenkoBrickBuffer.cs
+++ b/src/Core/RenkoBrickBuffer.cs
@@ -180,7 +180,9 @@ namespace Edison.Trading.Indicators
             {
                 lock (_lock)
                 {
-                    Directory.CreateDirectory(Path.GetDirectoryName(_protoPath)!);
+                    string? dir = Path.GetDirectoryName(_protoPath);
+                    if (!string.IsNullOrEmpty(dir))
+                        Directory.CreateDirectory(dir);
                     using var fs = new FileStream(_protoPath, FileMode.Append, FileAccess.Write, FileShare.Read);
                     var proto = new RenkoBrickProto
                     {

--- a/src/ProfitDLLClient/RenkoTradeMonitor.cs
+++ b/src/ProfitDLLClient/RenkoTradeMonitor.cs
@@ -14,6 +14,7 @@ namespace Edison.Trading.ProfitDLLClient
         private readonly RenkoBrickBuffer _brickBuffer;
         private readonly IProfitDLL _profitDll;
         private readonly TConnectorTradeCallback _dedicatedTradeCallback;
+        private readonly TConnectorTradeCallback _historyTradeCallback;
         private readonly string _symbol;
         private readonly string _exchange;
         private readonly object _lock = new object();
@@ -36,6 +37,8 @@ namespace Edison.Trading.ProfitDLLClient
 
             // Callback dedicado para Renko
             _dedicatedTradeCallback = new TConnectorTradeCallback(RenkoTradeCallback);
+            // Callback para histórico
+            _historyTradeCallback = new TConnectorTradeCallback(HistoryTradeCallback);
         }
 
         /// <summary>
@@ -55,6 +58,7 @@ namespace Edison.Trading.ProfitDLLClient
             ProfitDLL.UnsubscribeTicker(_symbol, _exchange);
             // P/Invoke permite null, mas a assinatura não é anulável
             ProfitDLL.SetTradeCallbackV2(null!);
+            ProfitDLL.SetHistoryTradeCallbackV2(null!);
             _renkoGenerator.OnCloseBrick -= _brickBuffer.AddBrick;
             _renkoGenerator.OnCloseBrick -= HandleNewBrick;
         }
@@ -79,13 +83,30 @@ namespace Edison.Trading.ProfitDLLClient
             }
         }
 
+        internal void HistoryTradeCallback(TConnectorAssetIdentifier a_Asset, nint a_pTrade, [MarshalAs(UnmanagedType.U4)] TConnectorTradeCallbackFlags a_nFlags)
+        {
+            if (a_Asset.Ticker != _symbol || a_Asset.Exchange != _exchange)
+                return;
+
+            var trade = new TConnectorTrade { Version = 0 };
+            if (_profitDll.TranslateTrade(a_pTrade, ref trade) == DLLConnector.NL_OK)
+            {
+                lock (_lock)
+                {
+                    _lastDclose = trade.Price;
+                    _renkoGenerator.AddPrice(trade.Price, trade.TradeDate);
+                }
+            }
+        }
+
         /// <summary>
         /// Manipulador chamado quando um novo tijolo Renko é fechado.
         /// </summary>
         private void HandleNewBrick(RenkoBrick brick)
         {
-            // Exemplo: log, estratégia, etc.
-            Console.WriteLine($"Novo tijolo: {brick.Direction} | {brick.Open} -> {brick.Close}");
+            var dt = SystemTime.ToDateTime(brick.Timestamp)
+                .ToString("dd/MM/yyyy HH:mm:ss.fff");
+            Console.WriteLine($"Novo tijolo em {dt} | {brick.Direction} | {brick.Open} -> {brick.Close}");
         }
 
         /// <summary>
@@ -117,6 +138,16 @@ namespace Edison.Trading.ProfitDLLClient
             out Memory<double> high, out Memory<double> low, out Memory<double> close)
         {
             _brickBuffer.ExtractSeries(out timestamps, out open, out high, out low, out close);
+        }
+
+        public void RequestHistory(DateTime start, DateTime end)
+        {
+            ProfitDLL.SetHistoryTradeCallbackV2(_historyTradeCallback);
+            ProfitDLL.GetHistoryTrades(
+                _symbol,
+                _exchange,
+                start.ToString("dd/MM/yyyy HH:mm:ss.fff"),
+                end.ToString("dd/MM/yyyy HH:mm:ss.fff"));
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add optional history fetch when starting renko monitor
- avoid failing when brick file has no directory
- show brick timestamp in console
- support GetHistoryTrades callback in RenkoTradeMonitor

## Testing
- `dotnet test Edison.Trading.sln -v minimal`
- `dotnet build Edison.Trading.sln -c Debug`


------
https://chatgpt.com/codex/tasks/task_e_686fe4735144832a9a2040c70ce0fcde