### PR TITLE
Fix AppendBrickToFile when given a filename only

### DIFF
--- a/src/Core/NelogicaRenkoGenerator.cs
+++ b/src/Core/NelogicaRenkoGenerator.cs
@@ -275,7 +275,9 @@ public class NelogicaRenkoGenerator
     {
         try
         {
-            Directory.CreateDirectory(Path.GetDirectoryName(_saveFilePath)!);
+            string? dir = Path.GetDirectoryName(_saveFilePath);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
             using var fs = new FileStream(_saveFilePath, FileMode.Append, FileAccess.Write, FileShare.Read);
             var proto = new RenkoBrickProto
             {

--- a/src/Core/RenkoBrickBuffer.cs
+++ b/src/Core/RenkoBrickBuffer.cs
@@ -180,7 +180,9 @@ namespace Edison.Trading.Indicators
             {
                 lock (_lock)
                 {
-                    Directory.CreateDirectory(Path.GetDirectoryName(_protoPath)!);
+                    string? dir = Path.GetDirectoryName(_protoPath);
+                    if (!string.IsNullOrEmpty(dir))
+                        Directory.CreateDirectory(dir);
                     using var fs = new FileStream(_protoPath, FileMode.Append, FileAccess.Write, FileShare.Read);
                     var proto = new RenkoBrickProto
                     {


### PR DESCRIPTION
## Summary
- fix directory creation in `RenkoBrickBuffer.AppendBrickToFile`
- fix directory creation in `NelogicaRenkoGenerator.AppendBrickToFile`

## Testing
- `dotnet restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68701080c590832a8e4f842f322e4d13