### PR TITLE
Add historical trade loading to Renko monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,9 @@ Execute the unit tests with:
 ```bash
 dotnet test
 ```
-main
+
+
+### Loading historical data in Renko mode
+
+When using the interactive console, the `start renko` command now prompts for an optional start date (`dd/MM/yyyy HH:mm:ss`).
+If provided, historical trades from that moment until now are loaded before subscribing to real-time data.


### PR DESCRIPTION
## Summary
- implement HistoryTradeCallback to translate and enqueue historical trades
- add LoadHistoryTrades helper
- prompt for optional history date when starting Renko monitoring
- document usage of the new option

## Testing
- `dotnet test tests/Edison.Trading.Tests.csproj --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687010b36380832a89fcd4e9bb399bea