### PR TITLE
Disable Renko history load and show timestamps

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -150,25 +150,9 @@ namespace Edison.Trading.Program
                         direction = string.Equals(dirInput, "down", StringComparison.OrdinalIgnoreCase) ? RenkoDirection.Down : RenkoDirection.Up;
                     }
 
-                    Console.Write("Data inicial para histórico (dd/MM/yyyy HH:mm:ss) ou pressione Enter para ignorar: ");
-                    string? startDtRaw = Console.ReadLine();
-                    DateTime startHist;
-                    bool loadHist = DateTime.TryParseExact(startDtRaw ?? string.Empty, "dd/MM/yyyy HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out startHist);
-
                     renkoGen.InitializeFromLastBrick(lastClose, direction);
                     monitor = new RenkoTradeMonitor(parts[0], parts[1], 15, 5.0, renkoGen);
 
-                    if (loadHist)
-                    {
-                        var history = ProfitDLLClient.DLLConnector.LoadHistoryTrades(parts[0], parts[1], startHist, DateTime.Now);
-                        foreach (var ht in history)
-                        {
-                            if (DateTime.TryParseExact(ht.Date, "dd/MM/yyyy HH:mm:ss.fff", CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt))
-                            {
-                                renkoGen.AddPrice(ht.Price, SystemTime.FromDateTime(dt));
-                            }
-                        }
-                    }
                     monitor.SelectAccount();
                     monitor.Start();
                     ProfitDLLClient.DLLConnector.WriteSync("🔄 Monitor Renko iniciado. Use 'stop renko' para parar.");

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ dotnet test
 ```
 
 
-### Loading historical data in Renko mode
+### Starting Renko mode
 
-When using the interactive console, the `start renko` command now prompts for an optional start date (`dd/MM/yyyy HH:mm:ss`).
-If provided, historical trades from that moment until now are loaded before subscribing to real-time data.
+The `start renko` command no longer asks for a history start date. Renko generation begins with the
+current market trades only. If no previously saved Renko data is found, you will be asked for the
+direction (`up` or `down`) of the last brick so the generator can continue from the current price.

--- a/src/ProfitDLLClient/RenkoTradeMonitor.cs
+++ b/src/ProfitDLLClient/RenkoTradeMonitor.cs
@@ -88,7 +88,8 @@ namespace Edison.Trading.ProfitDLLClient
         private void HandleNewBrick(RenkoBrick brick)
         {
             // Exemplo: log, estratégia, etc.
-            Console.WriteLine($"Novo tijolo: {brick.Direction} | {brick.Open} -> {brick.Close}");
+            var ts = SystemTime.ToDateTime(brick.Timestamp).ToString("HH:mm:ss.fff");
+            Console.WriteLine($"Novo tijolo: {brick.Direction} | {brick.Open} -> {brick.Close} @ {ts}");
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- remove the historical trade prompt from `start renko`
- log the timestamp when each Renko brick is created
- update README to describe new start behaviour

## Testing
- `dotnet test Edison.Trading.sln --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687018e8047c832abb7bb5c547cc7ca9