### PR TITLE
Fix Renko monitor to ignore history trades

### DIFF
--- a/src/ProfitDLLClient/RenkoTradeMonitor.cs
+++ b/src/ProfitDLLClient/RenkoTradeMonitor.cs
@@ -47,6 +47,13 @@ namespace Edison.Trading.ProfitDLLClient
         public void Start()
         {
             ProfitDLL.SubscribeTicker(_symbol, _exchange);
+            // Desativa o recebimento de trades históricos para evitar gerar
+            // vários tijolos com dados passados. O manual da ProfitDLL
+            // descreve que SetHistoryTradeCallbackV2 é a callback responsável
+            // por enviar histórico de trades, sinalizando o último pacote com a
+            // flag TC_LAST_PACKET. Para ignorar esse histórico, definimos a
+            // callback como null.
+            ProfitDLL.SetHistoryTradeCallbackV2(null!);
             ProfitDLL.SetTradeCallbackV2(_dedicatedTradeCallback);
         }
 


### PR DESCRIPTION
## Summary
- disable the history trade callback when starting the Renko monitor to avoid creating bricks from old trades

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68701fb3f5f0832aa4318ce750b6b6ea