### PR TITLE
Fix NUnit1033 analyzer warning

### DIFF
--- a/tests/NelogicaRenkoGeneratorTests.cs
+++ b/tests/NelogicaRenkoGeneratorTests.cs
@@ -213,7 +213,7 @@ public class NelogicaRenkoGeneratorTests
         table.AppendLine("OPEN,HIGH,LOW,CLOSE");
         foreach (var brick in generator.Bricks.Take(numBricksDesejados))
             table.AppendLine($"{brick.Open},{brick.High},{brick.Low},{brick.Close}");
-        TestContext.WriteLine(table.ToString());
+        TestContext.Out.WriteLine(table.ToString());
 
         // Testa buffer em memória
         Assert.That(generator.Bricks.TakeLast(bufferSize).Select(b => b.Close), Is.EqualTo(generator.Bricks.Skip(generator.Bricks.Count - bufferSize).Select(b => b.Close)));


### PR DESCRIPTION
## Summary
- address `NUnit1033` by writing test output to `TestContext.Out`

## Testing
- `dotnet test tests/Edison.Trading.Tests.csproj --no-build --nologo -v m`

------
https://chatgpt.com/codex/tasks/task_e_6871ab58ce88832aaf8c32985c3ad0a7